### PR TITLE
Remove property decorator from CheckingAccount.__repr__

### DIFF
--- a/projects/bank/bank.py
+++ b/projects/bank/bank.py
@@ -118,7 +118,6 @@ class CheckingAccount(Account):
     # TODO: Implement data members as properties
     ...
 
-    @property
     def __repr__(self) -> str:
         """Checking account representation"""
         # TODO: Implement this method


### PR DESCRIPTION
CheckingAccount.__repr__ is currently marked with @property, causing the error "TypeError: 'str' object is not callable" to be raised when running test_checking_account_repr.